### PR TITLE
Updating gradle syntax

### DIFF
--- a/android/build.gradle
+++ b/android/build.gradle
@@ -29,6 +29,6 @@ repositories {
 }
 
 dependencies {
-  compile 'com.facebook.react:react-native:+'
-  compile 'com.github.bumptech.glide:glide:3.8.0'
+  implementation 'com.facebook.react:react-native:+'
+  implementation 'com.github.bumptech.glide:glide:3.8.0'
 }


### PR DESCRIPTION
Updating gradle syntax. This is needed for Gradle 7 upgrade and Java upgrade. The alternative to this small changes is to pull in changes from `https://github.com/vovkasm/react-native-web-image` - which should trigger a bunch of extra QA-ing. Since the change is small, i think we should just make the change locally like this.